### PR TITLE
Adjust for COW-shared constant-folded PV buffers (Perl v5.41)

### DIFF
--- a/AM.xs
+++ b/AM.xs
@@ -1013,6 +1013,7 @@ _fillandcount(...)
       SV* this_class_sv = *hv_fetch(context_to_class, HeKEY(pointers_entry), NUM_LATTICES * sizeof(AM_SHORT), 0);
       AM_SHORT this_class = (AM_SHORT) SvUVX(this_class_sv);
       if (this_class) {
+        SV_CHECK_THINKFIRST(sum[this_class]);
         AM_LONG *s = (AM_LONG *) SvPVX(sum[this_class]);
         for (int i = 0; i < 7; ++i) {
           *(s + i) += gangcount[i];
@@ -1023,6 +1024,7 @@ _fillandcount(...)
         while (SvIOK(exemplar)) {
           IV datanum = SvIVX(exemplar);
           IV ocnum = SvIVX(classes[datanum]);
+          SV_CHECK_THINKFIRST(sum[ocnum]);
           AM_LONG *s = (AM_LONG *) SvPVX(sum[ocnum]);
           for (int i = 0; i < 7; ++i) {
             *(s + i) += p[i];


### PR DESCRIPTION
https://github.com/Perl/perl5/commit/06e421c559c63975f29c35ba3588a0e6b0c75eca made a change which allows constant folded PVs to have the `IsCOW` flag. The aim of this is to reduce unnecessary PV buffer copying and lower memory usage.

This caused some breakage in `AM.xs`, as some `sum[]` PV buffers became shared following this change, making it unsafe to modify them as-is. This commit calls `SV_CHECK_THINKFIRST()` on SVs found to be affected, which un-COWs the buffer by taking a fresh copy of it, prior to modifications being made.

Please refer to:
* http://www.cpantesters.org/cpan/report/90f70a84-3b21-11ef-897d-51c950bdeb56 as an
example of test failures now passing with bleadperl
* https://github.com/Perl/perl5/issues/22380 for general tracking of associated breakages.